### PR TITLE
Configure WOPI requests to remain within the Docker network

### DIFF
--- a/Containers/apache/Caddyfile
+++ b/Containers/apache/Caddyfile
@@ -15,6 +15,7 @@
 }
 
 https://{$ADDITIONAL_TRUSTED_DOMAIN}:443,
+http://${APACHE_HOST}:{$APACHE_PORT}, # For Collabora callback
 {$PROTOCOL}://{$NC_DOMAIN}:{$APACHE_PORT} {
     header -Server
     header -X-Powered-By

--- a/php/containers.json
+++ b/php/containers.json
@@ -379,7 +379,7 @@
       ],
       "internal_port": "9980",
       "environment": [
-        "aliasgroup1=https://%NC_DOMAIN%:443",
+        "aliasgroup1=https://%NC_DOMAIN%:443,http://nextcloud-aio-apache:%APACHE_PORT%",
         "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:mount_jail_tree=false --o:logging.level=warning --o:logging.level_startup=warning --o:home_mode.enable=true %COLLABORA_SECCOMP_POLICY% --o:remote_font_config.url=https://%NC_DOMAIN%/apps/richdocuments/settings/fonts.json --o:net.post_allow.host[0]=.+",
         "dictionaries=%COLLABORA_DICTIONARIES%",
         "TZ=%TIMEZONE%",
@@ -389,7 +389,7 @@
       "restart": "unless-stopped",
       "nextcloud_exec_commands": [
         "echo 'Activating Collabora config...'",
-        "php /var/www/html/occ richdocuments:activate-config"
+        "php /var/www/html/occ richdocuments:activate-config --wopi-url='http://nextcloud-aio-collabora:9980' --callback-url='http://nextcloud-aio-apache:%APACHE_PORT%'"
       ],
       "profiles": [
         "collabora"


### PR DESCRIPTION
Depends on https://github.com/nextcloud/all-in-one/pull/6568

This PR configures Collabora and Nextcloud to use the docker hostnames when communicating internally.

This fixes a few issues when AIO is behind a reverse proxy on another server outside of the docker network/LAN/default WOPI allow list.
- It increases performance saving a potentially expensive round trip
- It avoids needing the AIO host server's (possibly dynamic) public IP in the WOPI allow list

I think that it is fine for the Collabora <-> Nextcloud communication to be over HTTP and not HTTPS because it is within the docker network.

Before:
```
2025-06-20T03:52:43.330179992Z Activating Collabora config...
2025-06-20T03:52:43.901663506Z ✓ Reset callback url autodetect
2025-06-20T03:52:43.901688553Z Checking configuration
2025-06-20T03:52:43.901693541Z 🛈 Configured WOPI URL: https://nc.mydomain.me
2025-06-20T03:52:43.901697511Z 🛈 Configured public WOPI URL: https://nc.mydomain.me
2025-06-20T03:52:43.901701373Z 🛈 Configured callback URL: 
2025-06-20T03:52:43.901705189Z 
2025-06-20T03:52:44.622263890Z ✓ Fetched /hosting/discovery endpoint
2025-06-20T03:52:44.623698285Z ✓ Valid mimetype response
2025-06-20T03:52:44.624908960Z ✓ Valid capabilities entry
2025-06-20T03:52:44.897462696Z ✓ Fetched /hosting/capabilities endpoint
2025-06-20T03:52:44.897794791Z ✓ Detected WOPI server: Collabora Online Development Edition 25.04.2.2
2025-06-20T03:52:44.903921218Z 
2025-06-20T03:52:44.903961154Z Collabora URL (used for Nextcloud to contact the Collabora server):
2025-06-20T03:52:44.903975151Z   https://nc.mydomain.me
2025-06-20T03:52:44.903986670Z Collabora public URL (used in the browser to open Collabora):
2025-06-20T03:52:44.903998135Z   https://nc.mydomain.me
2025-06-20T03:52:44.904009056Z Callback URL (used by Collabora to connect back to Nextcloud):
2025-06-20T03:52:44.904020350Z   autodetected (will use the same URL as your user for browsing Nextcloud)
```

After:
```
Activating Collabora config...
✓ Set WOPI url to http://nextcloud-aio-collabora:9980
✓ Set callback url to http://nextcloud-aio-apache:11000
Checking configuration
🛈 Configured WOPI URL: http://nextcloud-aio-collabora:9980
🛈 Configured public WOPI URL: https://nc.mydomain.me
🛈 Configured callback URL: http://nextcloud-aio-apache:11000

✓ Fetched /hosting/discovery endpoint
✓ Valid mimetype response
✓ Valid capabilities entry
✓ Fetched /hosting/capabilities endpoint
✓ Detected WOPI server: Collabora Online Development Edition 25.04.2.2

Collabora URL (used for Nextcloud to contact the Collabora server):
  http://nextcloud-aio-collabora:9980
Collabora public URL (used in the browser to open Collabora):
  https://nc.mydomain.me
Callback URL (used by Collabora to connect back to Nextcloud):
  http://nextcloud-aio-apache:11000

```